### PR TITLE
Feature/add ts compatibility

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -22,7 +22,8 @@
       "Exceptions/*": [
         "src/exceptions/*",
         "../lesgo-framework/src/exceptions/*",
-        "node_modules/lesgo/src/exceptions/*"
+        "node_modules/lesgo/src/exceptions/*",
+        "node_modules/@types/lesgo/exceptions/*"
       ],
       "Handlers/*": [
         "src/handlers/*",
@@ -32,7 +33,8 @@
       "Middlewares/*": [
         "src/middlewares/*",
         "../lesgo-framework/src/middlewares/*",
-        "node_modules/lesgo/src/middlewares/*"
+        "node_modules/lesgo/src/middlewares/*",
+        "node_modules/@types/lesgo/middlewares/*"
       ],
       "Models/*": [
         "src/models/*",
@@ -42,12 +44,14 @@
       "Services/*": [
         "src/services/*",
         "../lesgo-framework/src/services/*",
-        "node_modules/lesgo/src/services/*"
+        "node_modules/lesgo/src/services/*",
+        "node_modules/@types/lesgo/services/*"
       ],
       "Utils/*": [
         "src/utils/*",
         "../lesgo-framework/src/utils/*",
-        "node_modules/lesgo/src/utils/*"
+        "node_modules/lesgo/src/utils/*",
+        "node_modules/@types/lesgo/utils/*"
       ]
     }
   },


### PR DESCRIPTION
## WHY
This is to add built in compatibility with @types/lesgo without breaking any structure.

## WHAT
The changes are implemented on a jsconfig.json file instead of tsconfig.json which will probably be converted to tsconfig.json when typescript is enabled